### PR TITLE
Version 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 simplecrypt/encrypter/encrypter
 default.etcd/
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/lancer-kit/noble.svg?branch=master)](https://travis-ci.com/github/lancer-kit/noble) 
+[![Build Status](https://travis-ci.com/lancer-kit/noble.svg?branch=master)](https://travis-ci.com/github/lancer-kit/noble)
 [![GoDoc](https://godoc.org/github.com/lancer-kit/noble?status.png)](https://godoc.org/github.com/lancer-kit/noble)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lancer-kit/noble)](https://goreportcard.com/report/github.com/lancer-kit/noble)
 
@@ -6,24 +6,38 @@
 
 No more secrets in github/gitlab repo's
 
->TOC
-* [Basic functionality](#noblesecret)
+> ## New in 1.2
+> #### Support for including multiple secrets inside parameter strings. 
+> #### Support for different types of secrets within one line. 
+Example of yaml config line:
+```yaml
+db: postgres://{{env:dbname}}?user={{dynenv:USER_NAME}}&password={{vault:/data/db?password}}
+```
+
+### TOC
+
+* [Basic functionality](#-noblesecret)
 * [Extension "simplecrypt".Just crypted strings in your config](#extension-simplecrypt)
 * [Extension "etcdr2".Read from **etcd** key/value API v2, ](#etcdr2)
 * [Extention "files".](#files)
 * [Extention "vaultx". Read stored keys from Hashicorp Vault](#vault)
 
-# noble.Secret 
+# noble.Secret
 -----------
 
 ### Simple string wrapper type for secret storage in config files.
 
-One type with support registration extensions (like a sql driver).
-Build-in supported storage type prefixes:
+One type with support registration extensions (like a sql driver). 
 
-* raw - just string (for debug/developing) 
+* raw - just string (for debug/developing)
 * env - read parameter from environment variable (see examples). read once on read from yaml/json
 * dynenv - read parameter from environment variable without caching (every time when you call .Get())
+* vault - read key from secure storage (**hashicorp vault**)
+* etcd2 - read value from selected key stored on **ETCD** by API v2  
+* scr - simple crypt value
+* file - read first line from text file as secret value
+
+Build-in (does not require importing extensions) supported storage type prefixes: raw, env, dynenv
 #### YAML config example:
 
 ```yaml
@@ -31,32 +45,38 @@ db:
   name: "sample"
   #just for development - store as is, change store type to scr, env/dynenv in prod
   user: 'raw:test:test?/test'
-  #read password stored in $DB_PASS once (cache value)
+  #read password stored in DB_PASS environment variable once (cache value)
   pass: env:DB_PASS
-
-#read password stored in $DB_PASS every time
+  #some datasource as string value
+  url: host=prodhost dbname=proddb user={{env:DB_USER}} password={{dynenv:DB_PASSWORD}} sslmode={{dynenv:SSL_MODE}}
+#read password stored in DB_PASS every time
 pass2: "dynenv:DB_PASS"
 ```
 
 #### Configure environment example:
+
 ```bash
 export DB_PASS=SomeStrongPassword
+export DB_USER=MyDBUSer
+export SSL_MODE=required
 ```
 
-
 #### Usage example:
+
 ```go
 package main
+
 import (
-  "github.com/lancer-kit/noble"
-  "gopkg.in/yaml.v2"
+	"github.com/lancer-kit/noble"
+	"gopkg.in/yaml.v2"
 )
 
 type testConfig struct {
 	Db struct {
-        Name  string       `yaml:"name"`
-		User  noble.Secret `yaml:"user"`
-		Pass  noble.Secret `yaml:"pass"`
+		Name string       `yaml:"name"`
+		User noble.Secret `yaml:"user"`
+		Pass noble.Secret `yaml:"pass"`
+		Url  noble.Secret `yaml:"url"`
 	} `yaml:"db"`
 	Pass2 noble.Secret     `yaml:"pass2"`
 }
@@ -78,16 +98,21 @@ func main(){
 }
 
 ```
+
 ### Extension "simplecrypt"
 
 Add type extension:
+
 * scr - simple crypt value
+
 ##### Yaml config example:
+
 ````yaml
 secret: scr:1Y2qKTtkeg5SmboJ970qENd54oBepinL5SF4dujQkY5Ec/J7M3bWQfiWaEPsZaXl4bPAEKoC1i29
+msg: "This is your key {{scr:1Y2qKTtkeg5SmboJ970qENd54oBepinL5SF4dujQkY5Ec/J7M3bWQfiWaEPsZaXl4bPAEKoC1i29}} to use"
 ````
-where scr - extension prefix
 
+where scr - extension prefix
 
 Build and use simplecrypt/encrypter to create key and encrypt values.
 
@@ -122,20 +147,25 @@ OPTIONS:
    --key value, -k value    key to encrypt value. [$SCR_PASS]
    --key value, -k value    key to encrypt value. [$SCR_PASS]
 ````
+
 ##### Usage:
 
->Just import package
+> Just import package
 
 ````go
 package main
+
 import _ "github.com/lancer-kit/noble/simplecrypt"
-//....
+
+//.... see example above
 ````
 
 ### ETCDR2
+
 ### Extension for etcd key/value API v2, "etcdr2"
 
 Add type extension:
+
 * etcd2 - read value from selected key stored on ETCD by API v2
 
 ##### Yaml config example:
@@ -144,14 +174,18 @@ Add type extension:
 secret: "etcd2:messages4/test"
 secret2: "etcd2:test2"
 secret3: "etcd2:messages4/keybox/test"
+user:
+  msg: "Your application ID:{{etcd2:test2}} to use with this APP!"
 ````
 
 Store value example:
+
 ````bash
 curl http://127.0.0.1:2379/v2/keys/messages4/test -XPUT -d value="Hello world"
 curl http://127.0.0.1:2379/v2/keys/test2 -XPUT -d value="Some very secret value"
 curl http://127.0.0.1:2379/v2/keys/messages4/keybox/test -XPUT -d value="One more secret value"
 ````
+
 ##### Usage:
 
 > Just import package
@@ -160,48 +194,62 @@ curl http://127.0.0.1:2379/v2/keys/messages4/keybox/test -XPUT -d value="One mor
 
 ````go
 package main
+
 import _ "github.com/lancer-kit/noble/etcdr2"
-//....
+
+//.... see example above
 ````
+
 ### Files
+
 ### Extension "files"
 
 Add type extension:
+
 * file - read first line from text file as secret value
 
 ##### Yaml config example:
 
 ````yaml
 secret: "file:/etc/noble/secret.cfg"
+user:
+  msg: "The first line is:{{file:./file.txt}}"
 ````
 
 ##### Usage:
 
->Just import package
-
+> Just import package
 
 ````go
 package main
+
 import _ "github.com/lancer-kit/noble/files"
-//....
+
+//.... see example above
 ````
+
 ### Vault
+
 ### Extension "vaultx"
 
 Add type extension:
+
 * vault - read key from secure storage (hashicorp vault)
-Key format:
+  Key format:
 
 `/<path>?<key>`
 
 For example, stored by command:
+
 ```ssh
 vault kv put secret/data/some-secured pass="my long password"    
 ```
+
 can be read by:
 
 ```yaml
 password: "vault:/data/some-secured?pass"
+someURI: "https://you.site.domain/return?token={{vault:/data?token}}&redirect={{env:PAGE}}"
 ```
 
 ##### Yaml config example:
@@ -212,30 +260,32 @@ secret: "vault:/data?key"
 
 ##### Usage:
 
->Just import package
-
+> Just import package
 
 ````go
 package main
-import (
 
-"github.com/lancer-kit/noble/vaultx"
-"log"
+import (
+	"github.com/lancer-kit/noble/vaultx"
+	"log"
 )
+
 //....
-func loadConfig(){
-  vaultx.SetServerAddress("https://vault.server.lan:2345")
-  if !vaultx.SetTokenEnv("VAULT_TOKEN"){
-        log.Fatal("environment var VAULT_TOKEN not set")
-  }
-  if err := vaultx.InitVault(nil);err!=nil{
-    log.Fatal(err)
-  }  
-  //... then load config file  
+func loadConfig() {
+	// initialize vault reader
+	vaultx.SetServerAddress("https://vault.server.lan:2345")
+	if !vaultx.SetTokenEnv("VAULT_TOKEN") {
+		log.Fatal("environment var VAULT_TOKEN not set")
+	}
+	if err := vaultx.InitVault(nil); err != nil {
+		log.Fatal(err)
+	}
+	// ... then load config file  
 }
 ````
 
 It is also possible to configure the following parameters:
+
 * `vaultx.SetLogger(logEntry)`: set logrus entry as log source;
 * `vaultx.SetServerAddress(address)`: set vault server address;
 * `vaultx.SetSecretPath(path)`: set vault k/v path. Used secret/data by default;

--- a/secret.go
+++ b/secret.go
@@ -19,29 +19,61 @@ var registered = map[string]SecretStorage{
 	"dynenv": &dynReader{},
 }
 
-// Secret object
 type Secret struct {
+	source      string
+	secrets     []*secret
+	single      bool
+	parseError  error
+	parsedParts []string
+}
+
+// secret object
+type secret struct {
 	reader     SecretStorage
 	path       string
 	parseError error
 	internal   error
 }
 
-func (sw Secret) Error() string {
-	if sw.internal != nil {
-		return sw.internal.Error()
+func (ss *Secret) Error() string {
+	if e := ss.ParseError(); e != nil {
+		return e.Error()
+	}
+	if e := ss.InternalError(); e != nil {
+		return e.Error()
 	}
 	return ""
 }
 
 // InternalError returns error
-func (sw Secret) InternalError() error {
-	return sw.internal
+func (ss *Secret) InternalError() error {
+	if len(ss.secrets) == 0 {
+		return ss.parseError
+	}
+	var err []string
+	for _, sr := range ss.secrets {
+		if sr.internal != nil {
+			err = append(err, sr.internal.Error())
+		}
+	}
+	if err == nil {
+		return nil
+	}
+	return errors.New(strings.Join(err, ";"))
 }
 
 // ParseError returns error
-func (sw Secret) ParseError() error {
-	return sw.parseError
+func (ss *Secret) ParseError() error {
+	var err []string
+	for _, sr := range ss.secrets {
+		if sr.parseError != nil {
+			err = append(err, sr.parseError.Error())
+		}
+	}
+	if err == nil {
+		return ss.parseError
+	}
+	return errors.New(strings.Join(err, ";"))
 }
 
 // Register new SecretStorage reader interface
@@ -50,33 +82,69 @@ func Register(key string, impl SecretStorage) {
 }
 
 // UnmarshalYAML read secrets from yaml
-func (sw *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ss *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
-	sw.parseError = sw.read(s)
+	_ = ss.readAll(s)
 	return nil
 }
 
 // UnmarshalJSON read secrets from json
-func (sw *Secret) UnmarshalJSON(data []byte) error {
+func (ss *Secret) UnmarshalJSON(data []byte) error {
 	var s string
 	if e := json.Unmarshal(data, &s); e != nil {
 		return e
 	}
-	sw.parseError = sw.read(s)
+	_ = ss.readAll(s)
 	return nil
 }
 
 // UnmarshalText from text formats
-func (sw *Secret) UnmarshalText(text []byte) error {
+func (sw *secret) UnmarshalText(text []byte) error {
 	sw.parseError = sw.read(string(text))
 	return nil
 }
 
-func (sw *Secret) read(s string) error {
+func (ss *Secret) readAll(in string) error {
+	ss.source = in
+	if !strings.Contains(in, "{{") {
+		ss.single = true
+		sr := secret{}.new(in)
+		if sr.parseError != nil {
+			ss.parseError = sr.parseError
+			return ss.parseError
+		}
+		ss.secrets = []*secret{&sr}
+		return nil
+	}
+	prc := in
+	for {
+		start := strings.Index(prc, "{{")
+		if start == -1 {
+			break
+		}
+		stop := strings.Index(prc, "}}")
+		if stop == -1 {
+			ss.parseError = errors.New("incorrect format. use [some text]{{<storage>:<path/name>}}[some text]")
+			return ss.parseError
+		}
+		sec := prc[start+2 : stop]
+		sr := new(secret)
+		if err := sr.read(sec); err != nil {
+			ss.parseError = err
+		}
+		ss.secrets = append(ss.secrets, sr)
+		ss.parsedParts = append(ss.parsedParts, prc[:start])
+		prc = prc[stop+2:]
+	}
+	ss.parsedParts = append(ss.parsedParts, prc)
+	return nil
+}
+
+func (sw *secret) read(s string) error {
 	parts := strings.SplitN(s, ":", 2)
 	if len(parts) != 2 {
 		sw.parseError = errors.New("incorrect format. use <storage>:<path/name>")
@@ -97,20 +165,46 @@ func (sw *Secret) read(s string) error {
 }
 
 // New static constructor
-func (sw Secret) New(s string) Secret {
-	val := Secret{}
+func (sw secret) new(s string) secret {
+	val := secret{}
 	_ = val.read(s)
 	return val
 }
 
+// New static constructor
+func (ss Secret) New(s string) Secret {
+	val := Secret{}
+	_ = val.readAll(s)
+	return val
+}
+
 // Get value getter
-func (sw *Secret) Get() string {
+func (sw *secret) Get() string {
 	if sw.reader == nil {
 		return ""
 	}
 	val, err := sw.reader.Read(sw.path)
 	sw.internal = err
 	return val
+}
+
+func (ss *Secret) Get() string {
+	if len(ss.secrets) == 0 {
+		return ss.source
+	}
+	if ss.single {
+		return ss.secrets[0].Get()
+	}
+	if len(ss.parsedParts) != len(ss.secrets)+1 {
+		ss.parseError = errors.New("parser error")
+		return ss.source
+	}
+	s := ss.parsedParts[0]
+	for i, sr := range ss.secrets {
+		s += sr.Get()
+		s += ss.parsedParts[i+1]
+	}
+	return s
 }
 
 type requiredSecretRule struct {
@@ -133,8 +227,10 @@ func (rd requiredSecretRule) Validate(value interface{}) error {
 	if s.ParseError() != nil {
 		return s.ParseError()
 	}
-	if s.reader == nil {
-		return errors.New("invalid value format. use <storage type>:<path/name/value...(depend on storage type)>")
+	for _, sr := range s.secrets {
+		if sr.reader == nil {
+			return errors.New("invalid value format. use <storage type>:<path/name/value...(depend on storage type)>")
+		}
 	}
 	s.Get()
 	return s.InternalError()

--- a/secret_test.go
+++ b/secret_test.go
@@ -18,14 +18,17 @@ db:
   user: 'raw:test:test?/test'
   pass: env:DB_PASS
   pass2: "dynenv:DB_PASS"
+  db_url: "sqlite://{{dynenv:DB_NAME}}?enableSome={{env:SEC}}"
 `
+const dbUrl = "sqlite://some?enableSome=sec"
 
 const jsonTest = `
 {
 "db":{
 	"user":"raw:test:test?/test",
 	"pass":"env:DB_PASS",
-	"pass2":"dynenv:DB_PASS"
+	"pass2":"dynenv:DB_PASS",
+	"db_url":"sqlite://{{dynenv:DB_NAME}}?enableSome={{env:SEC}}"
 	}
 }
 `
@@ -35,6 +38,7 @@ type testConfig struct {
 		User  Secret `yaml:"user" json:"user"`
 		Pass  Secret `yaml:"pass" json:"pass"`
 		Pass2 Secret `yaml:"pass2" json:"pass2"`
+		DbUrl Secret `yaml:"db_url" json:"db_url"`
 	} `yaml:"db" json:"db"`
 }
 
@@ -46,11 +50,12 @@ func TestSecretWrapper_New(t *testing.T) {
 
 func TestSecretWrapper_UnmarshalYAML(t *testing.T) {
 	tst := testConfig{}
-	e := os.Setenv("DB_PASS", envPass)
-	if !assert.NoError(t, e) {
+	if !assert.NoError(t, os.Setenv("DB_PASS", envPass)) {
 		return
 	}
-	e = yaml.Unmarshal([]byte(yamlTest), &tst)
+	assert.NoError(t, os.Setenv("DB_NAME", "some"))
+	assert.NoError(t, os.Setenv("SEC", "sec"))
+	e := yaml.Unmarshal([]byte(yamlTest), &tst)
 	if !assert.NoError(t, e) {
 		return
 	}
@@ -62,26 +67,111 @@ func TestSecretWrapper_UnmarshalYAML(t *testing.T) {
 	assert.Equal(t, envPass, tst.Db.Pass.Get())
 	assert.NoError(t, tst.Db.Pass.InternalError())
 	assert.Equal(t, envPass+user, tst.Db.Pass2.Get())
+	assert.Equal(t, dbUrl, tst.Db.DbUrl.Get())
 	assert.NoError(t, tst.Db.Pass2.InternalError())
+	assert.NoError(t, os.Unsetenv("DB_PASS"))
+	assert.NoError(t, os.Unsetenv("DB_NAME"))
+	assert.NoError(t, os.Unsetenv("SEC"))
 }
 
 func TestSecretWrapper_UnmarshalJSON(t *testing.T) {
 	tst := testConfig{}
-	e := os.Setenv("DB_PASS", envPass)
+	assert.NoError(t, os.Setenv("DB_NAME", "some"))
+	assert.NoError(t, os.Setenv("SEC", "sec"))
+	e := json.Unmarshal([]byte(jsonTest), &tst)
 	if !assert.NoError(t, e) {
 		return
 	}
-	e = json.Unmarshal([]byte(jsonTest), &tst)
-	if !assert.NoError(t, e) {
-		return
-	}
-	e = os.Setenv("DB_PASS", envPass+user)
-	if !assert.NoError(t, e) {
-		return
-	}
+	assert.NoError(t, os.Setenv("DB_PASS", envPass))
 	assert.Equal(t, user, tst.Db.User.Get())
 	assert.Equal(t, envPass, tst.Db.Pass.Get())
 	assert.NoError(t, tst.Db.Pass.InternalError())
+	assert.NoError(t, os.Setenv("DB_PASS", envPass+user))
 	assert.Equal(t, envPass+user, tst.Db.Pass2.Get())
 	assert.NoError(t, tst.Db.Pass2.InternalError())
+	assert.Equal(t, dbUrl, tst.Db.DbUrl.Get())
+	assert.NoError(t, tst.Db.DbUrl.InternalError())
+	assert.NoError(t, tst.Db.DbUrl.ParseError())
+	assert.NoError(t, os.Unsetenv("DB_PASS"))
+	assert.NoError(t, os.Unsetenv("DB_NAME"))
+	assert.NoError(t, os.Unsetenv("SEC"))
+}
+
+func TestSecret_Error(t *testing.T) {
+	s := Secret{}.New("some-test-data{{error here{{ }")
+	assert.Error(t, s.ParseError())
+	t.Logf("parse error: %s", s.Error())
+	assert.NotEmpty(t, s.Error())
+	s = Secret{}.New("some-test-data")
+	assert.Error(t, s.ParseError())
+	t.Logf("parse error: %s", s.Error())
+	assert.Equal(t, "some-test-data", s.Get())
+	assert.Error(t, s.InternalError())
+	assert.NotEmpty(t, s.Error())
+	s = Secret{}.New("{{raw:some-test-data}}")
+	assert.NoError(t, s.ParseError())
+	assert.NoError(t, s.InternalError())
+	assert.Empty(t, s.Error())
+	assert.Equal(t, "some-test-data", s.Get())
+	t.Logf("data is:%s", s.Get())
+	s = Secret{}.New("here is:\t{{raw:some-test-data}} new value of \n{{raw:test}} {.more}")
+	assert.NoError(t, s.ParseError())
+	assert.NoError(t, s.InternalError())
+	assert.Empty(t, s.Error())
+	t.Logf("data is:%s", s.Get())
+	assert.Equal(t, "here is:\tsome-test-data new value of \ntest {.more}", s.Get())
+	s = Secret{}.New("{{env:some-test-data}}")
+	assert.Error(t, s.ParseError())
+	assert.Error(t, s.InternalError())
+}
+
+func TestSecret_NoError(t *testing.T) {
+
+}
+
+func Test_secret_new(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantError  bool
+		parseError bool
+	}{
+		{
+			name: "raw",
+			args: args{s: "raw:some"},
+		},
+		{
+			name: "env",
+			args: args{s: "env:PATH"},
+		},
+		{
+			name:      "error read",
+			args:      args{s: "env:SOME_NOT_EXISTING"},
+			wantError: true,
+		},
+		{
+			name:       "error parse",
+			args:       args{s: "SOME_NOT_EXISTING"},
+			parseError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sec := secret{}.new(tt.args.s)
+			_ = sec.Get()
+			if tt.wantError {
+				assert.Error(t, sec.internal)
+			} else {
+				assert.NoError(t, sec.internal)
+			}
+			if tt.parseError {
+				assert.Error(t, sec.parseError)
+			} else {
+				assert.NoError(t, sec.parseError)
+			}
+		})
+	}
 }

--- a/simplecrypt/encrypter/encoder.go
+++ b/simplecrypt/encrypter/encoder.go
@@ -49,7 +49,7 @@ func genKey() string {
 	_, tmp := crypto.GenKeyPair()
 	key := []byte(tmp[:32])
 	println("Key len:", len(key))
-	return base64.RawStdEncoding.EncodeToString([]byte(key))
+	return base64.RawStdEncoding.EncodeToString(key)
 }
 
 func encryptValue(c *cli.Context) error {


### PR DESCRIPTION
## New in 1.2
#### Support for including multiple secrets inside parameter strings. 
#### Support for different types of secrets within one line. 
Example of yaml config line:
```yaml
db: postgres://{{env:dbname}}?user={{dynenv:USER_NAME}}&password={{vault:/data/db?password}}
```